### PR TITLE
State trie clearing fix

### DIFF
--- a/cmd/evm/main.go
+++ b/cmd/evm/main.go
@@ -163,7 +163,8 @@ func run(ctx *cli.Context) error {
 	vmdone := time.Since(tstart)
 
 	if ctx.GlobalBool(DumpFlag.Name) {
-		statedb.CommitTo(db, false)
+		statedb.IntermediateRoot(true)
+		statedb.CommitTo(db, true)
 		fmt.Println(string(statedb.Dump([]common.Address{})))
 	}
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -46,7 +46,7 @@ import (
 	"github.com/eth-classic/go-ethereum/pow"
 	"github.com/eth-classic/go-ethereum/rlp"
 	"github.com/eth-classic/go-ethereum/trie"
-	"github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru"
 )
 
 var (
@@ -1655,7 +1655,7 @@ func (bc *BlockChain) InsertChain(chain types.Blocks) (res *ChainInsertResult) {
 			return
 		}
 		// Write state changes to database
-		_, err = bc.stateCache.CommitTo(bc.chainDb, false)
+		_, err = bc.stateCache.CommitTo(bc.chainDb, bc.config.IsAtlantis(block.Number()))
 		if err != nil {
 			res.Error = err
 			return

--- a/core/chain_manager.go
+++ b/core/chain_manager.go
@@ -234,7 +234,7 @@ func GenerateChain(config *ChainConfig, parent *types.Block, db ethdb.Database, 
 			gen(i, b)
 		}
 		AccumulateRewards(config, statedb, h, b.uncles)
-		root, err := statedb.CommitTo(db, false)
+		root, err := statedb.CommitTo(db, config.IsAtlantis(b.header.Number))
 		if err != nil {
 			panic(fmt.Sprintf("state write error: %v", err))
 		}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -267,8 +267,7 @@ func (self *worker) wait() {
 				}
 				go self.mux.Post(core.NewMinedBlockEvent{Block: block})
 			} else {
-				// TODO: Check for state trie clearing here
-				work.state.CommitTo(self.chainDb, false)
+				work.state.CommitTo(self.chainDb, work.config.IsAtlantis(block.Number()))
 				parent := self.chain.GetBlock(block.ParentHash())
 				if parent == nil {
 					glog.V(logger.Error).Infoln("Invalid block found during mining")

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -267,6 +267,7 @@ func (self *worker) wait() {
 				}
 				go self.mux.Post(core.NewMinedBlockEvent{Block: block})
 			} else {
+				// TODO: Check for state trie clearing here
 				work.state.CommitTo(self.chainDb, false)
 				parent := self.chain.GetBlock(block.ParentHash())
 				if parent == nil {


### PR DESCRIPTION
Resolves https://github.com/eth-classic/go-ethereum/issues/81 and nodes are synced up as of now.

Point of contention could be the [miner/worker.go change](https://github.com/etclabscore/go-ethereum/compare/austin/commitstcfix#diff-83814d75e37ea3b4eb16ffc7202295d3R270) as it isn't related to this issue but maybe should be included (implicitly through the EIP spec).