### PR TITLE
modify dockerfile to switch to debian for whiteblock build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,21 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.12-alpine as builder
+FROM golang:1.12-stretch as builder
 
-RUN apk add --no-cache make gcc musl-dev linux-headers git
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get install -y gcc make git
 
 ADD . /go-ethereum
 
-RUN cd /go-ethereum && make cmd/geth
+WORKDIR /go-ethereum
 
-# Pull Geth into a second stage deploy alpine container
-FROM alpine:latest
+RUN make cmd/geth
 
-RUN apk add --no-cache ca-certificates
+# Pull Geth into a second stage deploy ubuntu container
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y openssh-server iputils-ping iperf3 && apt-get clean
 COPY --from=builder /go-ethereum/bin/geth /usr/local/bin/
 
 EXPOSE 8545 8546 30303 30303/udp
 ENTRYPOINT ["geth"]
-


### PR DESCRIPTION
Switched the dockerfile to use Ubuntu instead of Alpine for compatibility with the Whiteblock platform. The resulting image size is 259MB. If this is way to large, `iputils-ping iperf3` can be removed from the installed deps to reduce the image size, but will render commands `ping` and `iperf` unusable. I can also put this in a file called `whiteblock.dockerfile` if you would like to keep the current Dockerfile. 