### PR TITLE
Replace repository reference for accounts/abi/bind

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,3 +33,5 @@ require (
 	gopkg.in/karalabe/cookiejar.v2 v2.0.0-20150724131613-8dcd6a7f4951
 	gopkg.in/urfave/cli.v1 v1.17.0
 )
+
+replace github.com/eth-classic/go-ethereum/accounts/abi/bind v0.0.0-20190521151733-fe17e9e1e2ce => ./accounts/abi/bind


### PR DESCRIPTION
Currently it references eth-classic's bind module, but to make the rename #3 error free (last time we didn't change this and it is impossible to have the CI to pass when changing both remote references simultaneously. Not sure why the bind package was segregated, but in any case, this will relieve a headache in the future if you want. Also makes more logical sense since that module isn't a seperate repository.