### PR TITLE
Tx Encoding and decoding fix

### DIFF
--- a/core/database_util_test.go
+++ b/core/database_util_test.go
@@ -702,6 +702,62 @@ func TestReceiptStorage(t *testing.T) {
 	}
 }
 
+func TestOldReceiptStorageTransition(t *testing.T) {
+	var w bytes.Buffer
+	r := &types.Receipt{
+		Status:            types.TxSuccess,
+		CumulativeGasUsed: big.NewInt(1),
+		Logs: vm.Logs{
+			&vm.Log{Address: common.BytesToAddress([]byte{0x11})},
+			&vm.Log{Address: common.BytesToAddress([]byte{0x01, 0x11})},
+		},
+		TxHash:          common.BytesToHash([]byte{0x11, 0x11}),
+		ContractAddress: common.BytesToAddress([]byte{0x01, 0x11, 0x11}),
+		GasUsed:         big.NewInt(111111),
+	}
+
+	logs := make([]*vm.LogForStorage, len(r.Logs))
+	for i, log := range r.Logs {
+		logs[i] = (*vm.LogForStorage)(log)
+	}
+
+	rlp.Encode(&w, []interface{}{
+		r.PostState,
+		r.CumulativeGasUsed,
+		r.Bloom,
+		r.TxHash,
+		r.ContractAddress,
+		logs,
+		r.GasUsed,
+		r.Status,
+	})
+
+	var encodedReceipt types.ReceiptForStorage
+	stream := rlp.NewStream(bytes.NewReader(w.Bytes()), 0)
+	encodedReceipt.DecodeRLP(stream)
+
+	if encodedReceipt.Status != r.Status {
+		t.Errorf("Old storage receipt status: have (%v) want (%v)", encodedReceipt.Status, r.Status)
+	}
+	if encodedReceipt.CumulativeGasUsed.Cmp(r.CumulativeGasUsed) != 0 {
+		t.Errorf("Old storage receipt CumulativeGasUsed: have (%v) want (%v)", encodedReceipt.CumulativeGasUsed, r.CumulativeGasUsed)
+	}
+	if encodedReceipt.TxHash != r.TxHash {
+		t.Errorf("Old storage receipt TxHash: have (%v) want (%v)", encodedReceipt.TxHash, r.TxHash)
+	}
+	if encodedReceipt.ContractAddress != r.ContractAddress {
+		t.Errorf("Old storage receipt ContractAddress: have (%v) want (%v)", encodedReceipt.ContractAddress, r.ContractAddress)
+	}
+	if encodedReceipt.GasUsed.Cmp(r.GasUsed) != 0 {
+		t.Errorf("Old storage receipt GasUsed: have (%v) want (%v)", encodedReceipt.GasUsed, r.GasUsed)
+	}
+	for i, log := range r.Logs {
+		if bytes.Compare(r.Logs[i].Data, log.Data) != 0 {
+			t.Errorf("Old storage receipt Log: have (%v) want (%v)", log.Data, r.Logs[i].Data)
+		}
+	}
+}
+
 // Tests that receipts associated with a single block can be stored and retrieved.
 func TestBlockReceiptStorage(t *testing.T) {
 	db, _ := ethdb.NewMemDatabase()

--- a/core/database_util_test.go
+++ b/core/database_util_test.go
@@ -702,9 +702,56 @@ func TestReceiptStorage(t *testing.T) {
 	}
 }
 
+func TestReceiptStorageEncoding(t *testing.T) {
+	var w bytes.Buffer
+	r := &types.ReceiptForStorage{
+		PostState:         []byte{0x01, 0x02},
+		Status:            types.TxSuccess,
+		CumulativeGasUsed: big.NewInt(1),
+		Logs: vm.Logs{
+			&vm.Log{Address: common.BytesToAddress([]byte{0x11})},
+			&vm.Log{Address: common.BytesToAddress([]byte{0x01, 0x11})},
+		},
+		TxHash:          common.BytesToHash([]byte{0x12, 0x11}),
+		ContractAddress: common.BytesToAddress([]byte{0x01, 0x11, 0x11}),
+		GasUsed:         big.NewInt(111111),
+	}
+
+	r.EncodeRLP(&w)
+
+	var encodedReceipt types.ReceiptForStorage
+	stream := rlp.NewStream(bytes.NewReader(w.Bytes()), 0)
+	encodedReceipt.DecodeRLP(stream)
+
+	if bytes.Compare(encodedReceipt.PostState, r.PostState) != 0 {
+		t.Errorf("Old storage receipt PostState: have (%v) want (%v)", encodedReceipt.PostState, r.PostState)
+	}
+	if encodedReceipt.Status != r.Status {
+		t.Errorf("Old storage receipt status: have (%v) want (%v)", encodedReceipt.Status, r.Status)
+	}
+	if encodedReceipt.CumulativeGasUsed.Cmp(r.CumulativeGasUsed) != 0 {
+		t.Errorf("Old storage receipt CumulativeGasUsed: have (%v) want (%v)", encodedReceipt.CumulativeGasUsed, r.CumulativeGasUsed)
+	}
+	if encodedReceipt.TxHash != r.TxHash {
+		t.Errorf("Old storage receipt TxHash: have (%v) want (%v)", encodedReceipt.TxHash, r.TxHash)
+	}
+	if encodedReceipt.ContractAddress != r.ContractAddress {
+		t.Errorf("Old storage receipt ContractAddress: have (%v) want (%v)", encodedReceipt.ContractAddress, r.ContractAddress)
+	}
+	if encodedReceipt.GasUsed.Cmp(r.GasUsed) != 0 {
+		t.Errorf("Old storage receipt GasUsed: have (%v) want (%v)", encodedReceipt.GasUsed, r.GasUsed)
+	}
+	for i, log := range r.Logs {
+		if bytes.Compare(r.Logs[i].Data, log.Data) != 0 {
+			t.Errorf("Old storage receipt Log: have (%v) want (%v)", log.Data, r.Logs[i].Data)
+		}
+	}
+}
+
 func TestOldReceiptStorageTransition(t *testing.T) {
 	var w bytes.Buffer
 	r := &types.Receipt{
+		PostState:         []byte{0x24, 0x12},
 		Status:            types.TxSuccess,
 		CumulativeGasUsed: big.NewInt(1),
 		Logs: vm.Logs{
@@ -736,6 +783,9 @@ func TestOldReceiptStorageTransition(t *testing.T) {
 	stream := rlp.NewStream(bytes.NewReader(w.Bytes()), 0)
 	encodedReceipt.DecodeRLP(stream)
 
+	if bytes.Compare(encodedReceipt.PostState, r.PostState) != 0 {
+		t.Errorf("Old storage receipt PostState: have (%v) want (%v)", encodedReceipt.PostState, r.PostState)
+	}
 	if encodedReceipt.Status != r.Status {
 		t.Errorf("Old storage receipt status: have (%v) want (%v)", encodedReceipt.Status, r.Status)
 	}

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -66,8 +66,8 @@ type storedReceiptRLP struct {
 	GasUsed           *big.Int
 }
 
-// storedReceiptRLPv2 is the storage encoding of a receipt.
-type storedReceiptRLPv2 struct {
+// storedReceiptRLPWithStatus is the storage encoding of a receipt.
+type storedReceiptRLPWithStatus struct {
 	PostState         []byte
 	CumulativeGasUsed *big.Int
 	Bloom             Bloom
@@ -159,7 +159,7 @@ func (r *ReceiptForStorage) EncodeRLP(w io.Writer) error {
 	for i, log := range r.Logs {
 		logs[i] = (*vm.LogForStorage)(log)
 	}
-	receiptToStore := &storedReceiptRLPv2{
+	receiptToStore := &storedReceiptRLPWithStatus{
 		PostState:         r.PostState,
 		CumulativeGasUsed: r.CumulativeGasUsed,
 		Logs:              logs,
@@ -181,7 +181,7 @@ func (r *ReceiptForStorage) DecodeRLP(s *rlp.Stream) error {
 	}
 
 	// Try decoding the receipt with Status first
-	if err := decodeStoredReceiptRLPv2(r, raw); err == nil {
+	if err := decodeStoredReceiptRLPWithStatus(r, raw); err == nil {
 		return nil
 	}
 
@@ -226,8 +226,8 @@ func (r *ReceiptForStorage) decodePostStateOrStatus(sr storedReceiptRLP) {
 }
 
 // Decode with status field included in storage
-func decodeStoredReceiptRLPv2(r *ReceiptForStorage, raw []byte) error {
-	var receipt storedReceiptRLPv2
+func decodeStoredReceiptRLPWithStatus(r *ReceiptForStorage, raw []byte) error {
+	var receipt storedReceiptRLPWithStatus
 	if err := rlp.DecodeBytes(raw, &receipt); err != nil {
 		return err
 	}


### PR DESCRIPTION
Followed status encoding functions from foundation who implicitly ommitted PostState which altered the logic of the functionality of the receipt encoding and decoding, which was not caught by the existing tests or tests pulled from foundation.

Issue was if a Receipt in storage contained the PostState and Status, the Status would not be translated over into the returned value in favour of the PostState (which was removed and irrelevant at the current block).

I made these changes to remain compatible with all previous versions and now stores all fields without ommitting the PostState as was previously intended, but optimizations can be made later. I also added tests to ensure the compatibility and test these edge cases to make sure no changes affect the compatibility.

Please ensure the tx status appears on receipts migrating from a previous version, I cannot test that specifically.

Fixes #23 