### PR TITLE
updated TestParseNode to work with go v1.12.8

### DIFF
--- a/p2p/discover/node_test.go
+++ b/p2p/discover/node_test.go
@@ -150,7 +150,7 @@ func TestParseNode(t *testing.T) {
 			if err == nil {
 				t.Errorf("test %q:\n  got nil error, expected %#q", test.rawurl, test.wantError)
 				continue
-			} else if err.Error() != test.wantError {
+			} else if !strings.Contains(err.Error(), test.wantError) {
 				t.Errorf("test %q:\n  got error %#q, expected %#q", test.rawurl, err.Error(), test.wantError)
 				continue
 			}


### PR DESCRIPTION
resolves #41 